### PR TITLE
feat: support mcptotal.io

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -270,6 +270,7 @@ export function isExceptionHost(urlString: string): boolean {
     const exceptionHosts = new Set([
       'playground.ai.cloudflare.com',
       'mcp.docker.com',
+	  'mcptotal.io',
       // add more exception hosts here if needed
     ]);
     return exceptionHosts.has(url.hostname);


### PR DESCRIPTION
Hi. I've been trying to connect to Globalping through MCPTotal ([https://mcptotal.io](https://mcptotal.io)) and get an invalid redirect URI error. Hope this PR will be approved to allow the connection.