### PR TITLE
fix: enforce PKCE S256 validation on OAuth authorize endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -80,6 +80,25 @@ app.get("/authorize", async (c) => {
 		);
 	}
 
+	// Encforce PKCE with S256 for public clients (RFC 7636 section 4.2)
+	if (!oauthReqInfo.codeChallenge) {
+		return c.html(
+			layout(
+				await html`<h1>Invalid request</h1><p>PKCE code challenge is required.</p>`,
+				"Invalid request",
+			),
+		);
+	}
+
+	if (oauthReqInfo.codeChallengeMethod !== "S256") {
+		return c.html(
+			layout(
+				await html`<h1>Invalid request</h1><p>Only S256 code challenge method is supported.</p>`,
+				"Invalid request",
+			),
+		);
+	}
+
 	// Basic validation: just check redirect_uri is set and parsable
 	// The callback endpoint will later decide if auto-redirect or show manual confirmation
 	if (!oauthReqInfo.redirectUri) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -80,7 +80,7 @@ app.get("/authorize", async (c) => {
 		);
 	}
 
-	// Encforce PKCE with S256 for public clients (RFC 7636 section 4.2)
+	// Enforce PKCE with S256 for public clients (RFC 7636 section 4.2)
 	if (!oauthReqInfo.codeChallenge) {
 		return c.html(
 			layout(

--- a/test/integration/oauth-flow.test.ts
+++ b/test/integration/oauth-flow.test.ts
@@ -148,6 +148,84 @@ describe("OAuth Routes Integration", () => {
 			expect(html).toMatch(/Invalid request|Invalid redirect URI/);
 		});
 
+		it("should reject authorization request without code_challenge (PKCE bypass)", async () => {
+			const clientId = "test-pkce-client";
+			const clientRedirectUri = "http://localhost:3000/callback";
+			await env.OAUTH_KV.put(
+				`client:${clientId}`,
+				JSON.stringify({
+					clientId,
+					redirectUris: [clientRedirectUri],
+					clientName: "PKCE Test Client",
+				}),
+			);
+
+			const response = await SELF.fetch(
+				`http://localhost/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(clientRedirectUri)}&response_type=code&scope=measurements&state=test`,
+				{
+					method: "GET",
+					headers: { Host: "localhost" },
+				},
+			);
+
+			expect(response.status).toBe(200);
+			const html = await response.text();
+			expect(html).toContain("PKCE code challenge is required");
+		});
+
+		it("should reject authorization request with code_challenge_method=plain (PKCE downgrade)", async () => {
+			const clientId = "test-pkce-client";
+			const clientRedirectUri = "http://localhost:3000/callback";
+			await env.OAUTH_KV.put(
+				`client:${clientId}`,
+				JSON.stringify({
+					clientId,
+					redirectUris: [clientRedirectUri],
+					clientName: "PKCE Test Client",
+				}),
+			);
+
+			const response = await SELF.fetch(
+				`http://localhost/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(clientRedirectUri)}&response_type=code&scope=measurements&state=test&code_challenge=abc123&code_challenge_method=plain`,
+				{
+					method: "GET",
+					headers: { Host: "localhost" },
+				},
+			);
+
+			expect(response.status).toBe(200);
+			const html = await response.text();
+			expect(html).toContain("Only S256 code challenge method is supported");
+		});
+
+		it("should accept authorization request with valid S256 PKCE", async () => {
+			const clientId = "test-pkce-client";
+			const clientRedirectUri = "http://localhost:3000/callback";
+			await env.OAUTH_KV.put(
+				`client:${clientId}`,
+				JSON.stringify({
+					clientId,
+					redirectUris: [clientRedirectUri],
+					clientName: "PKCE Test Client",
+				}),
+			);
+
+			const response = await SELF.fetch(
+				`http://localhost/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(clientRedirectUri)}&response_type=code&scope=measurements&state=test&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256`,
+				{
+					method: "GET",
+					headers: { Host: "localhost" },
+					redirect: "manual",
+				},
+			);
+
+			expect(response.status).toBe(302);
+			const location = response.headers.get("Location");
+			expect(location).toContain("auth.globalping.io/oauth/authorize");
+			expect(location).toContain("code_challenge");
+			expect(location).toContain("code_challenge_method=S256");
+		});
+
 		it("should reject invalid redirect URI", async () => {
 			const response = await SELF.fetch(
 				"http://localhost/authorize?client_id=test&redirect_uri=https://evil.com&response_type=code&state=test",

--- a/test/integration/oauth-flow.test.ts
+++ b/test/integration/oauth-flow.test.ts
@@ -198,6 +198,31 @@ describe("OAuth Routes Integration", () => {
 			expect(html).toContain("Only S256 code challenge method is supported");
 		});
 
+		it("should reject authorization request with code_challenge but no code_challenge_method", async () => {
+			const clientId = "test-pkce-client";
+			const clientRedirectUri = "http://localhost:3000/callback";
+			await env.OAUTH_KV.put(
+				`client:${clientId}`,
+				JSON.stringify({
+					clientId,
+					redirectUris: [clientRedirectUri],
+					clientName: "PKCE Test Client",
+				}),
+			);
+
+			const response = await SELF.fetch(
+				`http://localhost/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(clientRedirectUri)}&response_type=code&scope=measurements&state=test&code_challenge=abc123`,
+				{
+					method: "GET",
+					headers: { Host: "localhost" },
+				},
+			);
+
+			expect(response.status).toBe(200);
+			const html = await response.text();
+			expect(html).toContain("Only S256 code challenge method is supported");
+		});
+
 		it("should accept authorization request with valid S256 PKCE", async () => {
 			const clientId = "test-pkce-client";
 			const clientRedirectUri = "http://localhost:3000/callback";


### PR DESCRIPTION
Reject authorization requests missing code_challenge or using code_challenge_method other than S256, preventing PKCE bypass and downgrade attacks on public MCP clients (RFC 7636)