### PR TITLE
updated workers-oauth-provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "globalping-mcp-server",
 			"version": "1.1.0",
 			"dependencies": {
-				"@cloudflare/workers-oauth-provider": "^0.1.0",
+				"@cloudflare/workers-oauth-provider": "^0.7.2",
 				"@modelcontextprotocol/sdk": "^1.20.2",
 				"agents": "^0.7.6",
 				"globalping": "^0.2.0",
@@ -1014,9 +1014,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-oauth-provider": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.1.0.tgz",
-			"integrity": "sha512-wok0RqyZlxkaKJCmGGXKyWkN0znRs9SFfTOJ1/TJxnv6N/lfXbCYr5hCbsgmOdvVi8JsKKYWj/qkqOLZybgAyQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.7.2.tgz",
+			"integrity": "sha512-GcSc2lTPYO/r9Zxyuvw8KNAk640LP5XTnBWVuI13hA6XcEWQbyH9KuO9WiN5pXUcO2Gn7pBmRTNU4uIMpgmw2w==",
 			"license": "MIT"
 		},
 		"node_modules/@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"wrangler": "^4.73.0"
 	},
 	"dependencies": {
-		"@cloudflare/workers-oauth-provider": "^0.1.0",
+		"@cloudflare/workers-oauth-provider": "^0.7.2",
 		"@modelcontextprotocol/sdk": "^1.20.2",
 		"agents": "^0.7.6",
 		"globalping": "^0.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,6 @@ export class GlobalpingMCP extends McpAgent<GlobalpingEnv, State, Props> {
 				tools: {
 					listChanged: true,
 				},
-				resources: {},
-				prompts: {},
-				logging: {},
 			},
 			instructions: `You have access to Globalping, a global network measurement platform. Use it to run ping, traceroute, DNS, MTR, and HTTP tests from thousands of locations worldwide.
 
@@ -601,6 +598,10 @@ export default {
 			tokenEndpoint: OAUTH_CONFIG.ENDPOINTS.TOKEN,
 			clientRegistrationEndpoint: OAUTH_CONFIG.ENDPOINTS.REGISTER,
 			scopesSupported: OAUTH_CONFIG.SCOPES,
+			resourceMetadata: {
+				resource: `${new URL(req.url).origin}/mcp`,
+				authorization_servers: [new URL(req.url).origin],
+			},
 		}).fetch(req, env, ctx);
 	},
 };


### PR DESCRIPTION
fix: update @cloudflare/workers-oauth-provider to version 0.7.2 and add resource metadata to handleMcpRequest

fixes Zero trust issue #33 