### PR TITLE
docs: clarify free rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ To use Globalping directly with Anthropic's Messages API (MCP Connector), pass t
 | `mtr` | Run combined ping and traceroute tests (My Traceroute) |
 | `http` | Execute HTTP/HTTPS requests from probes worldwide |
 | `locations` | List available Globalping probe regions and filters |
-| `limits` | Display current API quota and usage limits |
+| `limits` | Display the current free hourly test allowance and additional credits |
 | `getMeasurement` | Retrieve results of a historical measurement by ID |
 | `compareLocations` | Helper guide to compare multi-region performance metrics |
 | `help` | Tool reference and syntax documentation |
@@ -271,7 +271,7 @@ Locations can be specified using the location's `magic` parameter:
 
 * Remove and reconnect the integration to start a fresh OAuth flow.
 * For API-token authentication, generate a current token in the [Globalping dashboard](https://dash.globalping.io) and send it as `Authorization: Bearer YOUR_GLOBALPING_API_TOKEN`.
-* Once connected, use the `authStatus` tool to verify that authentication is active and the `limits` tool to check the available quota.
+* Once connected, use the `authStatus` tool to verify that authentication is active and the `limits` tool to check the free hourly test allowance and available credits. The displayed rate limit covers free tests only; authenticated users with credits can continue above it by spending one credit per additional test.
 
 ### Get help or report a problem
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,9 +259,9 @@ Available Tools:
    No parameters required
    Returns a list of probe locations grouped by continent and country
 
-7. limits - Show your current rate limits for the Globalping API
+7. limits - Show your current free test allowance and credits for the Globalping API
    No parameters required
-   Returns rate limit information for the Globalping API
+   The rate limit is the free hourly allowance, not a hard cap: authenticated users with credits can run additional tests by spending one credit per test
 
 8. getMeasurement - Retrieve a previously run measurement by ID
    Parameters:

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -721,7 +721,7 @@ export function registerGlobalpingTools(agent: GlobalpingMCP, getToken: () => st
 		{
 			title: "Check Rate Limits",
 			description:
-				"Check current API rate limits and remaining credits. Use this tool to monitor your usage quota and verify if you can perform additional measurements.",
+				"Check the current free hourly test allowance and remaining credits. The rateLimit fields describe only the free allowance, not a hard cap: authenticated users with credits can run additional tests after it is exhausted by spending one credit per test.",
 			annotations: {
 				readOnlyHint: true,
 				destructiveHint: false,
@@ -729,16 +729,29 @@ export function registerGlobalpingTools(agent: GlobalpingMCP, getToken: () => st
 			},
 			outputSchema: {
 				authenticated: z.boolean(),
-				rateLimit: z.object({
-					type: z.string(),
-					limit: z.number(),
-					remaining: z.number(),
-					reset: z.number(),
-				}),
+				rateLimit: z
+					.object({
+						type: z
+							.string()
+							.describe("Scope of the free test allowance, such as account or IP."),
+						limit: z
+							.number()
+							.describe("Total free tests available in the current window."),
+						remaining: z
+							.number()
+							.describe("Free tests remaining in the current window."),
+						reset: z.number().describe("Seconds until the free test allowance resets."),
+					})
+					.describe("The free hourly test allowance."),
 				credits: z
 					.object({
-						remaining: z.number(),
+						remaining: z
+							.number()
+							.describe(
+								"Number of remaining credits. One credit pays for one additional test.",
+							),
 					})
+					.describe("Credits available after the free allowance is exhausted.")
 					.optional(),
 			},
 		},
@@ -747,7 +760,7 @@ export function registerGlobalpingTools(agent: GlobalpingMCP, getToken: () => st
 				const token = getToken();
 				const limits = await getRateLimits(agent, token);
 
-				let textOutput = "Globalping Rate Limits:\n\n";
+				let textOutput = "Globalping Usage Limits:\n\n";
 
 				// Add authentication status to the output
 				textOutput += `Authentication Status: ${agent.getIsAuthenticated() ? "Authenticated" : "Unauthenticated"}\n`;
@@ -758,10 +771,10 @@ export function registerGlobalpingTools(agent: GlobalpingMCP, getToken: () => st
 				// Format parsed data
 				const rateLimit = limits.rateLimit.measurements.create;
 
-				textOutput += `Type: ${rateLimit.type}\n`;
-				textOutput += `Limit: ${rateLimit.limit} measurements\n`;
-				textOutput += `Remaining: ${rateLimit.remaining} measurements\n`;
-				textOutput += `Reset: in ${rateLimit.reset} seconds\n\n`;
+				textOutput += `Free Allowance Type: ${rateLimit.type}\n`;
+				textOutput += `Free Tests Limit: ${rateLimit.limit}\n`;
+				textOutput += `Free Tests Remaining: ${rateLimit.remaining}\n`;
+				textOutput += `Free Allowance Reset: in ${rateLimit.reset} seconds\n\n`;
 
 				if (limits.credits) {
 					textOutput += `Credits Remaining: ${limits.credits.remaining}\n`;

--- a/test/integration/mcp-tools.test.ts
+++ b/test/integration/mcp-tools.test.ts
@@ -505,7 +505,8 @@ describe("MCP Tools Integration", () => {
 			const data = await getMCPResponse(response);
 			expect(data.result).toBeDefined();
 			expect(data.result.content[0]).toHaveProperty("type", "text");
-			expect(data.result.content[0].text).toContain("rateLimit");
+			expect(data.result.content[0].text).toContain("Free Tests Limit");
+			expect(data.result.content[0].text).toContain("Credits Remaining");
 			expect(data.result.content[0].text).not.toContain("Token:");
 
 			// Verify mock API was called correctly


### PR DESCRIPTION
Explains that rateLimit covers only the free hourly test allowance and that authenticated users can exceed it by spending one credit per additional test.