### PR TITLE
fix: redact authorization headers from AgentCat

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import app from "./app";
 import { isAPITokenRequest, isValidAPIToken, sanitizeToken } from "./auth";
 import { AGENTCAT_CONFIG, MCP_CONFIG, OAUTH_CONFIG } from "./config";
-import { getCorsOptionsForRequest, validateHost, validateOrigin } from "./lib";
+import { getCorsOptionsForRequest, redactAgentCatEvent, validateHost, validateOrigin } from "./lib";
 import { registerGlobalpingTools } from "./mcp";
 import type { GlobalpingEnv, Props, State } from "./types";
 
@@ -57,6 +57,7 @@ Key guidelines:
 			try {
 				agentcat.track(this.server, this.env.MCPCAT_PROJECT_ID, {
 					enableToolCallContext: false,
+					redactEvent: redactAgentCatEvent,
 					resolveSessionId: () => this.getSessionId(),
 					// Identify users with generic labels
 					identify: async () => {

--- a/src/lib/agentcat.ts
+++ b/src/lib/agentcat.ts
@@ -1,0 +1,61 @@
+import type { RedactEventFunction } from "agentcat";
+
+const REDACTED_HEADER_VALUE = "[REDACTED]";
+
+function redactAuthorizationHeader(headers: unknown): unknown {
+	if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+		return headers;
+	}
+
+	return Object.fromEntries(
+		Object.entries(headers).map(([name, value]) => [
+			name,
+			name.toLowerCase() === "authorization" ? REDACTED_HEADER_VALUE : value,
+		]),
+	);
+}
+
+/**
+ * Removes incoming MCP Authorization values from AgentCat telemetry events.
+ */
+export const redactAgentCatEvent: RedactEventFunction = (event) => {
+	let redactedEvent = event;
+	const requestInfoHeaders = redactedEvent.parameters?.extra?.requestInfo?.headers;
+	if (requestInfoHeaders && typeof requestInfoHeaders === "object") {
+		redactedEvent = {
+			...redactedEvent,
+			parameters: {
+				...redactedEvent.parameters,
+				extra: {
+					...redactedEvent.parameters.extra,
+					requestInfo: {
+						...redactedEvent.parameters.extra.requestInfo,
+						headers: redactAuthorizationHeader(requestInfoHeaders),
+					},
+				},
+			},
+		};
+	}
+
+	const incomingHeaders = redactedEvent.parameters?.extra?.http?.req?.headers;
+	if (incomingHeaders && typeof incomingHeaders === "object") {
+		redactedEvent = {
+			...redactedEvent,
+			parameters: {
+				...redactedEvent.parameters,
+				extra: {
+					...redactedEvent.parameters.extra,
+					http: {
+						...redactedEvent.parameters.extra.http,
+						req: {
+							...redactedEvent.parameters.extra.http.req,
+							headers: redactAuthorizationHeader(incomingHeaders),
+						},
+					},
+				},
+			},
+		};
+	}
+
+	return redactedEvent;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,5 @@
+export * from "./agentcat";
 export * from "./crypto";
-export * from "./url-validation";
-export * from "./target-validation";
 export * from "./security";
+export * from "./target-validation";
+export * from "./url-validation";

--- a/test/integration/agentcat-public-contract.test.ts
+++ b/test/integration/agentcat-public-contract.test.ts
@@ -1,4 +1,4 @@
-import { SELF, env } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 declare global {
@@ -28,16 +28,19 @@ describe("AgentCat public MCP contract", () => {
 	let originalFetch: typeof globalThis.fetch;
 	let originalProjectId: string | undefined;
 	let telemetryFetch: ReturnType<typeof vi.fn>;
+	let telemetryPayloads: any[];
 
 	beforeEach(() => {
 		originalFetch = globalThis.fetch;
 		originalProjectId = env.MCPCAT_PROJECT_ID;
 		env.MCPCAT_PROJECT_ID = "agentcat-public-contract-test";
+		telemetryPayloads = [];
 		telemetryFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
 			const url = new URL(
 				typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
 			);
 			if (url.hostname.endsWith("agentcat.com")) {
+				telemetryPayloads.push(JSON.parse(String(init?.body)));
 				return new Response("{}", {
 					status: 200,
 					headers: { "Content-Type": "application/json" },
@@ -51,6 +54,85 @@ describe("AgentCat public MCP contract", () => {
 	afterEach(() => {
 		env.MCPCAT_PROJECT_ID = originalProjectId;
 		globalThis.fetch = originalFetch;
+	});
+
+	it("redacts only incoming MCP Authorization headers before AgentCat sends telemetry", async () => {
+		const send = async (message: unknown, sessionId?: string) => {
+			const response = await SELF.fetch("http://localhost/mcp", {
+				method: "POST",
+				headers: {
+					Host: "localhost",
+					Authorization: `Bearer ${token}`,
+					"Content-Type": "application/json",
+					Accept: "application/json, text/event-stream",
+					...(sessionId && { "Mcp-Session-Id": sessionId }),
+				},
+				body: JSON.stringify(message),
+			});
+			expect([200, 202]).toContain(response.status);
+			return response;
+		};
+
+		const initializeResponse = await send({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: {
+				protocolVersion: "2024-11-05",
+				capabilities: {},
+				clientInfo: { name: "agentcat-redaction-test", version: "1.0.0" },
+			},
+		});
+		const sessionId = initializeResponse.headers.get("Mcp-Session-Id");
+		expect(sessionId).toBeTruthy();
+
+		await send({ jsonrpc: "2.0", method: "notifications/initialized" }, sessionId!);
+		await send(
+			{
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/call",
+				params: { name: "compareLocations", arguments: {} },
+			},
+			sessionId!,
+		);
+		await send(
+			{
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: {
+					name: "http",
+					arguments: {
+						target: "localhost",
+						headers: {
+							"Set-Cookie": "measurement-cookie-secret",
+							"X-Access-Token": "measurement-token-secret",
+							"X-Client-Id": "measurement-client-id",
+						},
+					},
+				},
+			},
+			sessionId!,
+		);
+
+		await vi.waitFor(() => expect(telemetryPayloads).toHaveLength(2));
+
+		const measurementEvent = telemetryPayloads.find(
+			(payload) => payload.resourceName === "http",
+		);
+		const metadataEvent = telemetryPayloads.find(
+			(payload) => payload.resourceName === "compareLocations",
+		);
+		expect(metadataEvent.parameters.extra.requestInfo.headers.authorization).toBe("[REDACTED]");
+		expect(measurementEvent.parameters.request.params.arguments).toMatchObject({
+			target: "localhost",
+			headers: {
+				"Set-Cookie": "measurement-cookie-secret",
+				"X-Access-Token": "measurement-token-secret",
+				"X-Client-Id": "measurement-client-id",
+			},
+		});
 	});
 
 	it("does not expose disabled AgentCat context or session fields", async () => {

--- a/test/unit/lib/agentcat.test.ts
+++ b/test/unit/lib/agentcat.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { redactAgentCatEvent } from "../../../src/lib";
+
+describe("redactAgentCatEvent", () => {
+	it("redacts credential headers from current and v2 AgentCat request metadata without mutating other event data", () => {
+		const originalEvent = {
+			duration: 42,
+			resourceName: "http",
+			parameters: {
+				request: {
+					params: {
+						arguments: {
+							target: "example.com",
+							headers: { "X-Api-Key": "measurement-api-key-secret" },
+						},
+					},
+				},
+				extra: {
+					requestInfo: {
+						url: "https://mcp.globalping.io/mcp",
+						headers: {
+							Authorization: "Bearer incoming-authorization-secret",
+							"X-Authorization": "Bearer x-authorization-secret",
+							"Proxy-Authorization": "Basic incoming-proxy-secret",
+							"X-Original-Authorization": "Bearer original-authorization-secret",
+							"x-forwarded-authorization": "Bearer forwarded-authorization-secret",
+							"X-Auth": "incoming-auth-secret",
+							"X-Hub-Signature-256": "signature-secret",
+							"X-Access-Token": "incoming-token-secret",
+							"X-Secret": "incoming-secret",
+							"X-Secret-Key": "incoming-secret-key",
+							"X-Password": "incoming-password",
+							"X-Credential": "incoming-credential",
+							"X-Signature-Ed25519": "ed25519-signature-secret",
+							"X-Token-Count": "12",
+							"X-Password-Policy": "strong",
+							"X-Public-Key": "public-key-value",
+							"X-Client-Id": "incoming-client-id",
+						},
+					},
+					http: {
+						req: {
+							headers: {
+								authorization: "Bearer v2-authorization-secret",
+								Cookie: "session=incoming-cookie-secret",
+								"Set-Cookie": "incoming-set-cookie-secret",
+								"User-Agent": "agentcat-redaction-test/1.0",
+							},
+						},
+					},
+				},
+			},
+		};
+
+		const event = redactAgentCatEvent(originalEvent as any) as any;
+
+		expect(event).not.toBe(originalEvent);
+		expect(event.duration).toBe(42);
+		expect(event.resourceName).toBe("http");
+		expect(event.parameters.request.params.arguments).toEqual({
+			target: "example.com",
+			headers: { "X-Api-Key": "measurement-api-key-secret" },
+		});
+		expect(event.parameters.extra.requestInfo.headers).toMatchObject({
+			Authorization: "[REDACTED]",
+			"X-Authorization": "Bearer x-authorization-secret",
+			"Proxy-Authorization": "Basic incoming-proxy-secret",
+			"X-Original-Authorization": "Bearer original-authorization-secret",
+			"x-forwarded-authorization": "Bearer forwarded-authorization-secret",
+			"X-Auth": "incoming-auth-secret",
+			"X-Hub-Signature-256": "signature-secret",
+			"X-Access-Token": "incoming-token-secret",
+			"X-Secret": "incoming-secret",
+			"X-Secret-Key": "incoming-secret-key",
+			"X-Password": "incoming-password",
+			"X-Credential": "incoming-credential",
+			"X-Signature-Ed25519": "ed25519-signature-secret",
+			"X-Token-Count": "12",
+			"X-Password-Policy": "strong",
+			"X-Public-Key": "public-key-value",
+			"X-Client-Id": "incoming-client-id",
+		});
+		expect(event.parameters.extra.http.req.headers).toEqual({
+			authorization: "[REDACTED]",
+			Cookie: "session=incoming-cookie-secret",
+			"Set-Cookie": "incoming-set-cookie-secret",
+			"User-Agent": "agentcat-redaction-test/1.0",
+		});
+		expect(originalEvent.parameters.extra.requestInfo.headers.Authorization).toBe(
+			"Bearer incoming-authorization-secret",
+		);
+		expect(originalEvent.parameters.extra.requestInfo.headers["X-Token-Count"]).toBe("12");
+		expect(originalEvent.parameters.request.params.arguments.target).toBe("example.com");
+	});
+});


### PR DESCRIPTION
Part of https://github.com/jsdelivr/globalping-mcp-server/issues/39.